### PR TITLE
Add dark mode toggle

### DIFF
--- a/Frontend/src/Allcss/Footer.css
+++ b/Frontend/src/Allcss/Footer.css
@@ -1,6 +1,6 @@
 .footer {
-  background-color: rgb(230, 230, 230);
-  color: rgb(60, 60, 60);
+  background-color: var(--footer-background-color);
+  color: var(--footer-text-color);
   padding: 2rem;
   border-top: 1px solid #ddd;
   width: 100%;
@@ -22,7 +22,7 @@
 .footer-brand {
   font-size: 1.25rem;
   font-weight: 600;
-  color: rgb(60, 60, 60);
+  color: var(--footer-text-color);
 }
 
 .footer-nav {
@@ -35,18 +35,18 @@
 
 .footer-link {
   text-decoration: none;
-  color: rgb(60, 60, 60);
+  color: var(--footer-link-color);
   font-size: 1rem;
   transition: color 0.2s ease;
 }
 
 .footer-link:hover {
-  color: rgb(0, 0, 0);
+  color: var(--footer-text-color);
 }
 
 .footer-copyright {
   font-size: 0.875rem;
-  color: rgb(60, 60, 60);
+  color: var(--footer-text-color);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -6,15 +6,16 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
-  color: #222;
-  background-color: white;
+  color: var(--text-color);
+  background-color: var(--background-color);
 }
 
 .app-container {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background-color: white;
+  background-color: var(--background-color);
+  color: var(--text-color);
   position: relative;
 }
 
@@ -28,7 +29,8 @@ html, body {
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
-  background-color: white;
+  background-color: var(--background-color);
+  color: var(--text-color);
   margin-top: 72px;
   min-height: calc(100vh - 72px);
   position: relative;
@@ -59,8 +61,8 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: rgb(9, 9, 11);
-  color: white;
+  background-color: var(--header-background-color);
+  color: var(--header-text-color);
   padding: 0px 50px;
 }
 
@@ -166,8 +168,8 @@ form h1 {
 }
 
 footer {
-  background-color: rgb(230, 230, 230);
-  color: rgb(60, 60, 60);
+  background-color: var(--footer-background-color);
+  color: var(--footer-text-color);
   padding: 24px 40px;
   width: 100%;
   margin-top: auto;
@@ -190,13 +192,13 @@ footer nav {
 }
 
 footer nav a {
-  color: rgb(60, 60, 60);
+  color: var(--footer-link-color);
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 footer nav a:hover {
-  color: rgb(0, 0, 0);
+  color: var(--footer-text-color);
 }
 
 footer p {

--- a/Frontend/src/ThemeContext.js
+++ b/Frontend/src/ThemeContext.js
@@ -1,0 +1,25 @@
+import { createContext, useEffect, useState } from 'react';
+
+export const ThemeContext = createContext({ theme: 'light', toggleTheme: () => {} });
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    return stored ? stored : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -9,6 +9,8 @@
     --footer-background-color: #b1b9c2;
     --footer-text-color: #333;
     --footer-link-color: #333;
+    --header-background-color: #f5f5f5;
+    --header-text-color: #333;
   }
 
   [data-theme='dark'] {
@@ -17,6 +19,8 @@
     --footer-background-color: #1f1f1f;
     --footer-text-color: #f5f5f5;
     --footer-link-color: #f5f5f5;
+    --header-background-color: #1a1a1a;
+    --header-text-color: #ffffff;
   }
 
   body {

--- a/Frontend/src/index.js
+++ b/Frontend/src/index.js
@@ -2,13 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import {BrowserRouter} from "react-router-dom";
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from './ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
 
   </React.StrictMode>

--- a/Frontend/src/pages/HeaderPages/Header.js
+++ b/Frontend/src/pages/HeaderPages/Header.js
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { FaUser, FaUserCircle } from 'react-icons/fa';
+import { FaUser, FaUserCircle, FaSun, FaMoon } from 'react-icons/fa';
 import { UserContext } from '../../UserContext';
+import { ThemeContext } from '../../ThemeContext';
 import { Disclosure, Menu, MenuButton, MenuItem, MenuItems, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import { toast } from 'react-toastify';
 
@@ -30,6 +31,7 @@ function classNames(...classes) {
 export default function Header() {
   const navigate = useNavigate();
   const { userInfo, setUserInfo } = useContext(UserContext);
+  const { theme, toggleTheme } = useContext(ThemeContext);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -54,7 +56,7 @@ export default function Header() {
 
   
   return (
-    <Disclosure as="nav" className="bg-[#09090b] text-white">
+    <Disclosure as="nav" className="bg-[var(--header-background-color)] text-[var(--header-text-color)]">
       <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
         <div className="relative flex h-16 items-center justify-between">
           {/* Mobile menu button */}
@@ -80,7 +82,7 @@ export default function Header() {
                     key={item.name}
                     to={item.href}
                     className={classNames(
-                      'text-xs font-medium rounded-md px-2 py-2 hover:bg-[#6d8ded] transition-colors',
+                      'text-xs font-medium rounded-md px-2 py-2 hover:bg-[var(--header-background-color)] transition-colors',
                     )}
                   >
                     {item.name}
@@ -92,19 +94,32 @@ export default function Header() {
 
           {/* Right-side icons */}
           <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
-            {/* Notification Icon */}
-            <button
-              type="button"
-              className="relative rounded-full bg-[#1a1a1a] p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#09090b]">
-              <span className="absolute -inset-1.5" />
-              <span className="sr-only">View notifications</span>
-              <BellIcon aria-hidden="true" className="h-6 w-6" />
-            </button>
+          {/* Theme toggle */}
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="relative rounded-full bg-[var(--header-background-color)] p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#09090b] mr-3">
+            <span className="sr-only">Toggle theme</span>
+            {theme === 'dark' ? (
+              <FaSun className="h-6 w-6" />
+            ) : (
+              <FaMoon className="h-6 w-6" />
+            )}
+          </button>
+
+          {/* Notification Icon */}
+          <button
+            type="button"
+            className="relative rounded-full bg-[var(--header-background-color)] p-1 text-gray-400 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#09090b]">
+            <span className="absolute -inset-1.5" />
+            <span className="sr-only">View notifications</span>
+            <BellIcon aria-hidden="true" className="h-6 w-6" />
+          </button>
 
             {/* Profile dropdown */}
             <Menu as="div" className="relative ml-3">
               <div>
-                <MenuButton className="flex rounded-full bg-[#1a1a1a] text-sm focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#09090b]">
+                <MenuButton className="flex rounded-full bg-[var(--header-background-color)] text-sm focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-[#09090b]">
                   <span className="sr-only">Open user menu</span>
                   {userInfo ? (
                     <FaUserCircle className="h-8 w-8 rounded-full text-white" />
@@ -113,7 +128,7 @@ export default function Header() {
                   )}
                 </MenuButton>
               </div>
-              <MenuItems className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-[#1a1a1a] shadow-lg py-1 ring-1 ring-black/5">
+              <MenuItems className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-[var(--header-background-color)] shadow-lg py-1 ring-1 ring-black/5">
                 {userInfo ? (
                   <>
                     <MenuItem>

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
     "./public/index.html"


### PR DESCRIPTION
## Summary
- add ThemeContext and provider
- wrap app with ThemeProvider
- add theme toggle button to Header for dark/light mode
- use CSS variables in App.css and Footer.css for theming
- define theme colors in index.css

## Testing
- `npm --prefix Frontend test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bea5d99a88326bcfdd1dd1f8121ce